### PR TITLE
Add shortlink support, remove the need for config domain name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ Flask-Cors==3.0.10
 yt-dlp==2022.10.4
 pymongo==4.2.0
 boto3==1.24.89
+requests==2.28.1
+idna<4,>=2.5
+urllib3<1.27,>=1.21.1
+certifi>=2017.4.17
+charset-normalizer<3,>=2


### PR DESCRIPTION
Nice service, but I found it to be pretty useless for links that come from the mobile app, because they are shortened links. 

So, I've added support for links that look like:
`vt.tiktok.com/Z9ULvrKAn` (fake link)

The mechanism behind it is just fetching the short link. It returns a 301 with a Location header which contains a long link - just what we need for yt-dlp
I've also changed how it detects the username links; that includes not having to worry about the config domain name anymore.

To use this, all you have to do is paste the link after the domain, like so:
`https://vxtiktok.com/vt.tiktok.com/Z9ULvrKAn`.
Not the best solution but I didn't have other ideas. 

I've tested it on my selfhosted instance, seemed to work fine.

<sub>P.S. your instance seems to be broken right now, hope you can fix it soon. It always returns `{"message":"Internal Server Error"}`</sub>